### PR TITLE
add avalanche config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -128,7 +128,11 @@ const userConfig: HardhatUserConfig = {
     fantomTestnet: {
       ...sharedNetworkConfig,
       url: `https://rpc.testnet.fantom.network/`,
-    }
+    },
+    avalanche: {
+      ...sharedNetworkConfig,
+      url: `https://api.avax.network/ext/bc/C/rpc`,
+    },
   },
   deterministicDeployment,
   namedAccounts: {


### PR DESCRIPTION
I had to add these networks to redeploy the 1.3.0 SignMessageLib contract