### PR TITLE
feat: support signatures from contracts implementing the updated EIP1271

### DIFF
--- a/contracts/GnosisSafe.sol
+++ b/contracts/GnosisSafe.sol
@@ -285,7 +285,7 @@ contract GnosisSafe is
                     contractSignature := add(add(signatures, s), 0x20)
                 }
 
-                checkSmartContractSignature(currentOwner, data, contractSignature);
+                checkContractSignature(currentOwner, data, contractSignature);
             } else if (v == 1) {
                 // If v is 1 then it is an approved hash
                 // When handling approved hashes the address of the approver is encoded into r
@@ -306,7 +306,7 @@ contract GnosisSafe is
         }
     }
 
-    function checkSmartContractSignature(address currentOwner, bytes memory data, bytes memory contracSignature) internal view {
+    function checkContractSignature(address currentOwner, bytes memory data, bytes memory contracSignature) internal view {
         bool success;
         bytes memory res;
 

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -16,7 +16,6 @@ contract CompatibilityFallbackHandler is DefaultCallbackHandler, ISignatureValid
     bytes4 internal constant SIMULATE_SELECTOR = bytes4(keccak256("simulate(address,bytes)"));
 
     address internal constant SENTINEL_MODULES = address(0x1);
-    bytes4 internal constant UPDATED_MAGIC_VALUE = 0x1626ba7e;
 
     /**
      * Implementation of ISignatureValidator (see `interfaces/ISignatureValidator.sol`)
@@ -66,7 +65,7 @@ contract CompatibilityFallbackHandler is DefaultCallbackHandler, ISignatureValid
     function isValidSignature(bytes32 _dataHash, bytes calldata _signature) external view returns (bytes4) {
         ISignatureValidator validator = ISignatureValidator(msg.sender);
         bytes4 value = validator.isValidSignature(abi.encode(_dataHash), _signature);
-        return (value == EIP1271_MAGIC_VALUE) ? UPDATED_MAGIC_VALUE : bytes4(0);
+        return (value == EIP1271_MAGIC_VALUE) ? EIP1271_UPDATED_MAGIC_VALUE : bytes4(0);
     }
 
     /// @dev Returns array of first 10 modules.

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -3,11 +3,12 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import "./DefaultCallbackHandler.sol";
 import "../interfaces/ISignatureValidator.sol";
+import "../interfaces/IEIP1271UpdatedSignatureValidator.sol";
 import "../GnosisSafe.sol";
 
 /// @title Compatibility Fallback Handler - fallback handler to provider compatibility between pre 1.3.0 and 1.3.0+ Safe contracts
 /// @author Richard Meissner - <richard@gnosis.pm>
-contract CompatibilityFallbackHandler is DefaultCallbackHandler, ISignatureValidator {
+contract CompatibilityFallbackHandler is DefaultCallbackHandler, ISignatureValidator, IEIP1271UpdatedSignatureValidator {
     //keccak256(
     //    "SafeMessage(bytes message)"
     //);
@@ -62,7 +63,7 @@ contract CompatibilityFallbackHandler is DefaultCallbackHandler, ISignatureValid
      * @return a bool upon valid or invalid signature with corresponding _dataHash
      * @notice See https://github.com/gnosis/util-contracts/blob/bb5fe5fb5df6d8400998094fb1b32a178a47c3a1/contracts/StorageAccessible.sol
      */
-    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) external view returns (bytes4) {
+    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) public view override returns (bytes4) {
         ISignatureValidator validator = ISignatureValidator(msg.sender);
         bytes4 value = validator.isValidSignature(abi.encode(_dataHash), _signature);
         return (value == EIP1271_MAGIC_VALUE) ? EIP1271_UPDATED_MAGIC_VALUE : bytes4(0);

--- a/contracts/interfaces/IEIP1271UpdatedSignatureValidator.sol
+++ b/contracts/interfaces/IEIP1271UpdatedSignatureValidator.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+contract IEIP1271UpdatedSignatureValidatorConstants {
+    // bytes4(keccak256("isValidSignature(bytes32,bytes)")
+    bytes4 internal constant EIP1271_UPDATED_MAGIC_VALUE = 0x1626ba7e;
+}
+
+abstract contract IEIP1271UpdatedSignatureValidator is IEIP1271UpdatedSignatureValidatorConstants {
+    /**
+     * Implementation of updated EIP-1271
+     * @dev Should return whether the signature provided is valid for the provided data
+     * @param _data Hash of the data signed on the behalf of address(this)
+     * @param _signature Signature byte array associated with _data
+     *
+     * MUST return the bytes4 magic value 0x1626ba7e when function passes.
+     * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
+     * MUST allow external calls
+     */
+    function isValidSignature(bytes32 _data, bytes memory _signature) public view virtual returns (bytes4);
+}

--- a/contracts/interfaces/ISignatureValidator.sol
+++ b/contracts/interfaces/ISignatureValidator.sol
@@ -4,9 +4,6 @@ pragma solidity >=0.7.0 <0.9.0;
 contract ISignatureValidatorConstants {
     // bytes4(keccak256("isValidSignature(bytes,bytes)")
     bytes4 internal constant EIP1271_MAGIC_VALUE = 0x20c13b0b;
-
-    // bytes4(keccak256("isValidSignature(bytes32,bytes)")
-    bytes4 internal constant EIP1271_UPDATED_MAGIC_VALUE = 0x1626ba7e;
 }
 
 abstract contract ISignatureValidator is ISignatureValidatorConstants {
@@ -20,16 +17,4 @@ abstract contract ISignatureValidator is ISignatureValidatorConstants {
      * MUST allow external calls
      */
     function isValidSignature(bytes memory _data, bytes memory _signature) public view virtual returns (bytes4);
-
-    /**
-     * Implementation of updated EIP-1271
-     * @dev Should return whether the signature provided is valid for the provided data
-     * @param _data Hash of the data signed on the behalf of address(this)
-     * @param _signature Signature byte array associated with _data
-     *
-     * MUST return the bytes4 magic value 0x1626ba7e when function passes.
-     * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
-     * MUST allow external calls
-     */
-    function isValidSignature(bytes32 _data, bytes memory _signature) public view virtual returns (bytes4);
 }

--- a/contracts/interfaces/ISignatureValidator.sol
+++ b/contracts/interfaces/ISignatureValidator.sol
@@ -4,6 +4,9 @@ pragma solidity >=0.7.0 <0.9.0;
 contract ISignatureValidatorConstants {
     // bytes4(keccak256("isValidSignature(bytes,bytes)")
     bytes4 internal constant EIP1271_MAGIC_VALUE = 0x20c13b0b;
+
+    // bytes4(keccak256("isValidSignature(bytes32,bytes)")
+    bytes4 internal constant EIP1271_UPDATED_MAGIC_VALUE = 0x1626ba7e;
 }
 
 abstract contract ISignatureValidator is ISignatureValidatorConstants {
@@ -17,4 +20,16 @@ abstract contract ISignatureValidator is ISignatureValidatorConstants {
      * MUST allow external calls
      */
     function isValidSignature(bytes memory _data, bytes memory _signature) public view virtual returns (bytes4);
+
+    /**
+     * Implementation of updated EIP-1271
+     * @dev Should return whether the signature provided is valid for the provided data
+     * @param _data Hash of the data signed on the behalf of address(this)
+     * @param _signature Signature byte array associated with _data
+     *
+     * MUST return the bytes4 magic value 0x1626ba7e when function passes.
+     * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
+     * MUST allow external calls
+     */
+    function isValidSignature(bytes32 _data, bytes memory _signature) public view virtual returns (bytes4);
 }


### PR DESCRIPTION
Hi! 

This PR adds support for the updated EIP1271 to the core Gnosis Safe. 

Why I have added a new Interface file? Well, because [Solidity doesn't support yet selectors with the same name](https://github.com/ethereum/solidity/issues/12409). 

Also, I refactored things in the fallback handler. 

Note: Obviously an audit is needed. 
Note2: I've not added test (yet) cause the contract signature case has no test and I was not sure if you would like to merge the PR or not. Didn't find any doc related to why this is not supported yet. 