### PR TITLE
Pad storage addresses passed to `getStorageAt()` to 66 chars

### DIFF
--- a/test/libraries/Migration.spec.ts
+++ b/test/libraries/Migration.spec.ts
@@ -46,9 +46,9 @@ describe("Migration", async () => {
             const { safe, migration, singleton120 } = await setupTests()
             // The emit matcher checks the address, which is the Safe as delegatecall is used
             const migrationSafe = migration.attach(safe.address)
-            
+
             await expect(
-                await ethers.provider.getStorageAt(safe.address, "0x06")
+                await ethers.provider.getStorageAt(safe.address, "0x" + "".padEnd(62, "0") + "06")
             ).to.be.eq("0x" + "".padEnd(64, "0"))
 
             await expect(


### PR DESCRIPTION
Hardhat 2.9.5 released yesterday introduced a requirement for storage addresses passed to `getStorageAt()` to be padded to full 32 bytes. Currently the Safe has one test that uses an unpadded argument and that test is failing with latest Hardhat.

This PR adds the missing padding. Note that Hardhat has a bug that makes it still reject the properly padded address (https://github.com/NomicFoundation/hardhat/issues/2709) but once that's fixed, this change will be enough to solve the issue.

### Failing test
```bash
hardhat test test/libraries/Migration.spec.ts
```
```
  Migration
    constructor
      ✓ can not use 0 Address
    migrate
      ✓ can only be called from Safe itself

      1) can migrate


  2 passing (3s)
  1 failing

  1) Migration
       migrate
         can migrate:
     InvalidArgumentsError: Errors encountered in param 1: Storage slot argument must have a length of 66 ("0x" + 32 bytes), but '0x6' has a length of 3
      at validateParams (node_modules/hardhat/src/internal/core/jsonrpc/types/input/validation.ts:64:13)
      at EthModule._getStorageAtParams (node_modules/hardhat/src/internal/hardhat-network/provider/modules/eth.ts:695:26)
      at EthModule.processRequest (node_modules/hardhat/src/internal/hardhat-network/provider/modules/eth.ts:185:49)
      at HardhatNetworkProvider._send (node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:195:31)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at runNextTicks (node:internal/process/task_queues:65:3)
      at listOnTimeout (node:internal/timers:528:9)
      at processTimers (node:internal/timers:502:7)
      at HardhatNetworkProvider.request (node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:118:18)
```