### PR TITLE
Docs: Fix return value comment

### DIFF
--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -23,7 +23,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
      * @dev Implementation of ISignatureValidator (see `interfaces/ISignatureValidator.sol`)
      * @param _data Arbitrary length data signed on the behalf of address(msg.sender).
      * @param _signature Signature byte array associated with _data.
-     * @return a bool upon valid or invalid signature with corresponding _data.
+     * @return The EIP-1271 magic value.
      */
     function isValidSignature(bytes memory _data, bytes memory _signature) public view override returns (bytes4) {
         // Caller should be a Safe


### PR DESCRIPTION
Https://github.com/safe-global/safe-contracts/pull/547 initially fixed it.

It fixes an incorrect documentation for the EIP-1271 method return value