### PR TITLE
Support updated EIP-1271 implementation for signature validation

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -270,7 +270,7 @@ contract Safe is
      *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
      * @param requiredSignatures Amount of required valid signatures.
      */
-    function checkNSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures, uint256 requiredSignatures) public view {
+    function checkNSignatures(bytes32 dataHash, bytes memory /* data */, bytes memory signatures, uint256 requiredSignatures) public view {
         // Check that the provided signature data is not too short
         require(signatures.length >= requiredSignatures.mul(65), "GS020");
         // There cannot be an owner with address 0.

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -265,6 +265,9 @@ contract Safe is
     /**
      * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
      * @dev Since the EIP-1271 does an external call, be mindful of reentrancy attacks.
+     *      The data parameter (bytes) is not used since v1.5.0 as it is not required anymore. Prior to v1.5.0,
+     *      data parameter was used in contract signature validation flow using legacy EIP-1271.
+     *      Version v1.5.0, uses dataHash parameter instead of data with updated EIP-1271 implementation.
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
      * @param signatures Signature data that should be verified.
      *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -310,10 +310,7 @@ contract Safe is
                     // The signature data for contract signatures is appended to the concatenated signatures and the offset is stored in s
                     contractSignature := add(add(signatures, s), 0x20)
                 }
-                require(
-                    ISignatureValidator(currentOwner).isValidSignature(abi.encode(dataHash), contractSignature) == EIP1271_MAGIC_VALUE,
-                    "GS024"
-                );
+                require(ISignatureValidator(currentOwner).isValidSignature(dataHash, contractSignature) == EIP1271_MAGIC_VALUE, "GS024");
             } else if (v == 1) {
                 // If v is 1 then it is an approved hash
                 // When handling approved hashes the address of the approver is encoded into r

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -12,6 +12,7 @@ import "./common/SecuredTokenTransfer.sol";
 import "./common/StorageAccessible.sol";
 import "./interfaces/ISignatureValidator.sol";
 import "./external/SafeMath.sol";
+
 /**
  * @title Safe - A multisignature wallet with support for confirmations using signed messages based on EIP-712.
  * @dev Most important concepts:
@@ -309,7 +310,10 @@ contract Safe is
                     // The signature data for contract signatures is appended to the concatenated signatures and the offset is stored in s
                     contractSignature := add(add(signatures, s), 0x20)
                 }
-                require(ISignatureValidator(currentOwner).isValidSignature(abi.encode(dataHash), contractSignature) == EIP1271_MAGIC_VALUE, "GS024");
+                require(
+                    ISignatureValidator(currentOwner).isValidSignature(abi.encode(dataHash), contractSignature) == EIP1271_MAGIC_VALUE,
+                    "GS024"
+                );
             } else if (v == 1) {
                 // If v is 1 then it is an approved hash
                 // When handling approved hashes the address of the approver is encoded into r

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "./TokenCallbackHandler.sol";
 import "../interfaces/ISignatureValidator.sol";
 import "../Safe.sol";
-    
+
 /**
  * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
  * @author Richard Meissner - @rmeissner

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -16,27 +16,6 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
     bytes4 internal constant SIMULATE_SELECTOR = bytes4(keccak256("simulate(address,bytes)"));
 
     address internal constant SENTINEL_MODULES = address(0x1);
-    bytes4 internal constant UPDATED_MAGIC_VALUE = 0x1626ba7e;
-
-    /**
-     * @notice Legacy EIP-1271 signature validation method.
-     * @dev Implementation of ISignatureValidator (see `interfaces/ISignatureValidator.sol`)
-     * @param _data Arbitrary length data signed on the behalf of address(msg.sender).
-     * @param _signature Signature byte array associated with _data.
-     * @return The EIP-1271 magic value.
-     */
-    function isValidSignature(bytes memory _data, bytes memory _signature) public view override returns (bytes4) {
-        // Caller should be a Safe
-        Safe safe = Safe(payable(msg.sender));
-        bytes memory messageData = encodeMessageDataForSafe(safe, _data);
-        bytes32 messageHash = keccak256(messageData);
-        if (_signature.length == 0) {
-            require(safe.signedMessages(messageHash) != 0, "Hash not approved");
-        } else {
-            safe.checkSignatures(messageHash, messageData, _signature);
-        }
-        return EIP1271_MAGIC_VALUE;
-    }
 
     /**
      * @dev Returns the hash of a message to be signed by owners.
@@ -74,10 +53,17 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
      * @param _signature Signature byte array associated with _dataHash
      * @return Updated EIP1271 magic value if signature is valid, otherwise 0x0
      */
-    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) external view override returns (bytes4) {
-        ISignatureValidator validator = ISignatureValidator(msg.sender);
-        bytes4 value = validator.isValidSignature(abi.encode(_dataHash), _signature);
-        return (value == EIP1271_MAGIC_VALUE) ? UPDATED_MAGIC_VALUE : bytes4(0);
+    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) public view override returns (bytes4) {
+        // Caller should be a Safe
+        Safe safe = Safe(payable(msg.sender));
+        bytes memory messageData = encodeMessageDataForSafe(safe, abi.encode(_dataHash));
+        bytes32 messageHash = keccak256(messageData);
+        if (_signature.length == 0) {
+            require(safe.signedMessages(messageHash) != 0, "Hash not approved");
+        } else {
+            safe.checkSignatures(messageHash, messageData, _signature);
+        }
+        return EIP1271_MAGIC_VALUE;
     }
 
     /**

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -4,9 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "./TokenCallbackHandler.sol";
 import "../interfaces/ISignatureValidator.sol";
 import "../Safe.sol";
-
-import "hardhat/console.sol";
-
+    
 /**
  * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
  * @author Richard Meissner - @rmeissner
@@ -76,7 +74,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
      * @param _signature Signature byte array associated with _dataHash
      * @return Updated EIP1271 magic value if signature is valid, otherwise 0x0
      */
-    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) public view returns (bytes4) {
+    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) external view override returns (bytes4) {
         ISignatureValidator validator = ISignatureValidator(msg.sender);
         bytes4 value = validator.isValidSignature(abi.encode(_dataHash), _signature);
         return (value == EIP1271_MAGIC_VALUE) ? UPDATED_MAGIC_VALUE : bytes4(0);

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -5,6 +5,8 @@ import "./TokenCallbackHandler.sol";
 import "../interfaces/ISignatureValidator.sol";
 import "../Safe.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
  * @author Richard Meissner - @rmeissner
@@ -30,6 +32,10 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
         Safe safe = Safe(payable(msg.sender));
         bytes memory messageData = encodeMessageDataForSafe(safe, _data);
         bytes32 messageHash = keccak256(messageData);
+        console.log("SOLIDITY");
+        console.logBytes(messageData);
+        console.logBytes32(messageHash);
+        console.log("SOLIDITY END");
         if (_signature.length == 0) {
             require(safe.signedMessages(messageHash) != 0, "Hash not approved");
         } else {

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.7.0 <0.9.0;
 import "./TokenCallbackHandler.sol";
 import "../interfaces/ISignatureValidator.sol";
 import "../Safe.sol";
-
 /**
  * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
  * @author Richard Meissner - @rmeissner
@@ -74,7 +73,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
      * @param _signature Signature byte array associated with _dataHash
      * @return Updated EIP1271 magic value if signature is valid, otherwise 0x0
      */
-    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) external view returns (bytes4) {
+    function isValidSignature(bytes32 _dataHash, bytes calldata _signature) public view returns (bytes4) {
         ISignatureValidator validator = ISignatureValidator(msg.sender);
         bytes4 value = validator.isValidSignature(abi.encode(_dataHash), _signature);
         return (value == EIP1271_MAGIC_VALUE) ? UPDATED_MAGIC_VALUE : bytes4(0);

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -32,10 +32,6 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
         Safe safe = Safe(payable(msg.sender));
         bytes memory messageData = encodeMessageDataForSafe(safe, _data);
         bytes32 messageHash = keccak256(messageData);
-        console.log("SOLIDITY");
-        console.logBytes(messageData);
-        console.logBytes32(messageHash);
-        console.log("SOLIDITY END");
         if (_signature.length == 0) {
             require(safe.signedMessages(messageHash) != 0, "Hash not approved");
         } else {

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "./TokenCallbackHandler.sol";
 import "../interfaces/ISignatureValidator.sol";
 import "../Safe.sol";
+
 /**
  * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
  * @author Richard Meissner - @rmeissner

--- a/contracts/interfaces/ISignatureValidator.sol
+++ b/contracts/interfaces/ISignatureValidator.sol
@@ -2,22 +2,11 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 contract ISignatureValidatorConstants {
-    // bytes4(keccak256("isValidSignature(bytes,bytes)")
-    bytes4 internal constant EIP1271_MAGIC_VALUE = 0x20c13b0b;
+    // bytes4(keccak256("isValidSignature(bytes32,bytes)")
+    bytes4 internal constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
 }
 
 abstract contract ISignatureValidator is ISignatureValidatorConstants {
-    /**
-     * @notice Legacy EIP1271 method to validate a signature.
-     * @param _data Arbitrary length data signed on the behalf of address(this).
-     * @param _signature Signature byte array associated with _data.
-     *
-     * MUST return the bytes4 magic value 0x20c13b0b when function passes.
-     * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
-     * MUST allow external calls
-     */
-    function isValidSignature(bytes memory _data, bytes memory _signature) public view virtual returns (bytes4);
-
     /**
      * @notice EIP1271 method to validate a signature.
      * @param _hash Hash of the data signed on the behalf of address(this).

--- a/contracts/interfaces/ISignatureValidator.sol
+++ b/contracts/interfaces/ISignatureValidator.sol
@@ -17,4 +17,15 @@ abstract contract ISignatureValidator is ISignatureValidatorConstants {
      * MUST allow external calls
      */
     function isValidSignature(bytes memory _data, bytes memory _signature) public view virtual returns (bytes4);
+
+    /**
+     * @notice EIP1271 method to validate a signature.
+     * @param _hash Hash of the data signed on the behalf of address(this).
+     * @param _signature Signature byte array associated with _data.
+     *
+     * MUST return the bytes4 magic value 0x1626ba7e when function passes.
+     * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
+     * MUST allow external calls
+     */
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external view virtual returns (bytes4);
 }

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -19,7 +19,6 @@
 - `GS024`: `Invalid contract signature provided`
 - `GS025`: `Hash has not been approved`
 - `GS026`: `Invalid owner provided`
-- `GS027`: `Data Hash and hash of the pre-image data do not match`
 
 ### General auth related
 - `GS030`: `Only owners can approve a hash`

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -225,7 +225,11 @@ describe("Safe", async () => {
             const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address, signerSafe.address]);
             const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() });
 
-            const safeMessageHash = calculateSafeMessageHash(signerSafe, calculateSafeTransactionHash(safe, tx, await chainId()), await chainId());
+            const safeMessageHash = calculateSafeMessageHash(
+                signerSafe,
+                calculateSafeTransactionHash(safe, tx, await chainId()),
+                await chainId(),
+            );
             const signerSafeOwnerSignature = await signHash(user5, safeMessageHash);
             const signerSafeSig = buildContractSignature(signerSafe.address, signerSafeOwnerSignature.data);
 

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -4,7 +4,6 @@ import { expect } from "chai";
 import { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 import { AddressZero } from "@ethersproject/constants";
-import crypto from "crypto";
 import { getSafeTemplate, getSafeWithOwners } from "../utils/setup";
 import {
     safeSignTypedData,
@@ -230,9 +229,9 @@ describe("Safe", async () => {
                 calculateSafeTransactionHash(safe, tx, await chainId()),
                 await chainId(),
             );
+
             const signerSafeOwnerSignature = await signHash(user5, safeMessageHash);
             const signerSafeSig = buildContractSignature(signerSafe.address, signerSafeOwnerSignature.data);
-
             await expect(
                 logGas(
                     "Execute cancel transaction with 5 owners (1 owner is another Safe)",
@@ -261,7 +260,7 @@ describe("Safe", async () => {
                 "0000000000000000000000000000000000000000000000000000000000000020" +
                 "00" + // r, s, v
                 "0000000000000000000000000000000000000000000000000000000000000000"; // Some data to read
-            await expect(safe.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS021");
+            await expect(safe.checkSignatures(txHash, "0x", signatures)).to.be.revertedWith("GS021");
         });
 
         it("should fail if signatures data is not present", async () => {

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -1,4 +1,4 @@
-import { buildContractSignature } from "./../../src/utils/execution";
+import { buildContractSignature, calculateSafeMessageHash } from "./../../src/utils/execution";
 import { expect } from "chai";
 import hre, { deployments, waffle, ethers } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
@@ -137,7 +137,7 @@ describe("CompatibilityFallbackHandler", async () => {
             expect(await validator.callStatic["isValidSignature(bytes32,bytes)"](dataHash, "0x")).to.be.eq("0x1626ba7e");
         });
 
-        it("should return magic value if enough owners signed and allow a mix different signature types", async () => {
+        it.only("should return magic value if enough owners signed and allow a mix different signature types", async () => {
             const { validator, signerSafe } = await setupTests();
             const dataHash = ethers.utils.keccak256("0xbaddad");
             const typedDataSig = {
@@ -149,8 +149,9 @@ describe("CompatibilityFallbackHandler", async () => {
                 ),
             };
             const ethSignSig = await signHash(user2, calculateSafeMessageHash(validator, dataHash, await chainId()));
-            const validatorPreImageMessage = preimageSafeMessageHash(validator, dataHash, await chainId());
-            const signerSafeMessageHash = calculateSafeMessageHash(signerSafe, validatorPreImageMessage, await chainId());
+            const validatorSafeMessageHash = calculateSafeMessageHash(validator, dataHash, await chainId());
+            const signerSafeMessageHash = calculateSafeMessageHash(signerSafe, validatorSafeMessageHash, await chainId());
+
             const signerSafeOwnerSignature = await signHash(user1, signerSafeMessageHash);
             const signerSafeSig = buildContractSignature(signerSafe.address, signerSafeOwnerSignature.data);
 

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -8,7 +8,6 @@ import {
     buildSignatureBytes,
     executeContractCallWithSigners,
     calculateSafeMessageHash,
-    preimageSafeMessageHash,
     EIP712_SAFE_MESSAGE_TYPE,
     signHash,
 } from "../../src/utils/execution";
@@ -63,55 +62,6 @@ describe("CompatibilityFallbackHandler", async () => {
         });
     });
 
-    describe("isValidSignature(bytes,bytes)", async () => {
-        it("should revert if called directly", async () => {
-            const { handler } = await setupTests();
-            await expect(handler.callStatic["isValidSignature(bytes,bytes)"]("0xbaddad", "0x")).to.be.revertedWith(
-                "function call to a non-contract account",
-            );
-        });
-
-        it("should revert if message was not signed", async () => {
-            const { validator } = await setupTests();
-            await expect(validator.callStatic["isValidSignature(bytes,bytes)"]("0xbaddad", "0x")).to.be.revertedWith("Hash not approved");
-        });
-
-        it("should revert if signature is not valid", async () => {
-            const { validator } = await setupTests();
-            await expect(validator.callStatic["isValidSignature(bytes,bytes)"]("0xbaddad", "0xdeaddeaddeaddead")).to.be.reverted;
-        });
-
-        it("should return magic value if message was signed", async () => {
-            const { safe, validator, signLib } = await setupTests();
-            await executeContractCallWithSigners(safe, signLib, "signMessage", ["0xbaddad"], [user1, user2], true);
-            expect(await validator.callStatic["isValidSignature(bytes,bytes)"]("0xbaddad", "0x")).to.be.eq("0x20c13b0b");
-        });
-
-        it("should return magic value if enough owners signed and allow a mix different signature types", async () => {
-            const { validator, signerSafe } = await setupTests();
-            const sig1 = {
-                signer: user1.address,
-                data: await user1._signTypedData(
-                    { verifyingContract: validator.address, chainId: await chainId() },
-                    EIP712_SAFE_MESSAGE_TYPE,
-                    { message: "0xbaddad" },
-                ),
-            };
-            const sig2 = await signHash(user2, calculateSafeMessageHash(validator, "0xbaddad", await chainId()));
-            const signerSafeMessageHash = calculateSafeMessageHash(
-                signerSafe,
-                calculateSafeMessageHash(validator, "0xbaddad", await chainId()),
-                await chainId(),
-            );
-            const signerSafeOwnerSignature = await signHash(user1, signerSafeMessageHash);
-            const signerSafeSig = buildContractSignature(signerSafe.address, signerSafeOwnerSignature.data);
-
-            expect(
-                await validator.callStatic["isValidSignature(bytes,bytes)"]("0xbaddad", buildSignatureBytes([sig1, sig2, signerSafeSig])),
-            ).to.be.eq("0x20c13b0b");
-        });
-    });
-
     describe("isValidSignature(bytes32,bytes)", async () => {
         it("should revert if called directly", async () => {
             const { handler } = await setupTests();
@@ -156,6 +106,7 @@ describe("CompatibilityFallbackHandler", async () => {
             const signerSafeMessageHash = calculateSafeMessageHash(signerSafe, validatorSafeMessageHash, await chainId());
 
             const signerSafeOwnerSignature = await signHash(user1, signerSafeMessageHash);
+
             const signerSafeSig = buildContractSignature(signerSafe.address, signerSafeOwnerSignature.data);
 
             expect(

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -98,8 +98,7 @@ describe("CompatibilityFallbackHandler", async () => {
                 ),
             };
             const sig2 = await signHash(user2, calculateSafeMessageHash(validator, "0xbaddad", await chainId()));
-            const validatorPreImageMessage = preimageSafeMessageHash(validator, "0xbaddad", await chainId());
-            const signerSafeMessageHash = calculateSafeMessageHash(signerSafe, validatorPreImageMessage, await chainId());
+            const signerSafeMessageHash = calculateSafeMessageHash(signerSafe, calculateSafeMessageHash(validator, "0xbaddad", await chainId()), await chainId());
             const signerSafeOwnerSignature = await signHash(user1, signerSafeMessageHash);
             const signerSafeSig = buildContractSignature(signerSafe.address, signerSafeOwnerSignature.data);
 
@@ -137,7 +136,7 @@ describe("CompatibilityFallbackHandler", async () => {
             expect(await validator.callStatic["isValidSignature(bytes32,bytes)"](dataHash, "0x")).to.be.eq("0x1626ba7e");
         });
 
-        it.only("should return magic value if enough owners signed and allow a mix different signature types", async () => {
+        it("should return magic value if enough owners signed and allow a mix different signature types", async () => {
             const { validator, signerSafe } = await setupTests();
             const dataHash = ethers.utils.keccak256("0xbaddad");
             const typedDataSig = {

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -98,7 +98,11 @@ describe("CompatibilityFallbackHandler", async () => {
                 ),
             };
             const sig2 = await signHash(user2, calculateSafeMessageHash(validator, "0xbaddad", await chainId()));
-            const signerSafeMessageHash = calculateSafeMessageHash(signerSafe, calculateSafeMessageHash(validator, "0xbaddad", await chainId()), await chainId());
+            const signerSafeMessageHash = calculateSafeMessageHash(
+                signerSafe,
+                calculateSafeMessageHash(validator, "0xbaddad", await chainId()),
+                await chainId(),
+            );
             const signerSafeOwnerSignature = await signHash(user1, signerSafeMessageHash);
             const signerSafeSig = buildContractSignature(signerSafe.address, signerSafeOwnerSignature.data);
 

--- a/test/integration/Safe.0xExploit.spec.ts
+++ b/test/integration/Safe.0xExploit.spec.ts
@@ -5,7 +5,7 @@ import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
 import { defaultAbiCoder } from "@ethersproject/abi";
 import { getSafeWithOwners, deployContract, getCompatFallbackHandler } from "../utils/setup";
-import { buildSignatureBytes, executeContractCallWithSigners, signHash} from "../../src/utils/execution";
+import { buildSignatureBytes, executeContractCallWithSigners, signHash } from "../../src/utils/execution";
 
 describe("Safe", async () => {
     const [user1, user2] = waffle.provider.getWallets();

--- a/test/integration/Safe.0xExploit.spec.ts
+++ b/test/integration/Safe.0xExploit.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
-import hre, { deployments, waffle } from "hardhat";
+import hre, { deployments, ethers, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
 import { defaultAbiCoder } from "@ethersproject/abi";
 import { getSafeWithOwners, deployContract, getCompatFallbackHandler } from "../utils/setup";
-import { buildSignatureBytes, executeContractCallWithSigners, signHash } from "../../src/utils/execution";
+import { buildSignatureBytes, executeContractCallWithSigners, signHash} from "../../src/utils/execution";
 
 describe("Safe", async () => {
     const [user1, user2] = waffle.provider.getWallets();
@@ -41,7 +41,7 @@ describe("Safe", async () => {
 
             // Use off-chain Safe signature
             const messageData = await safe.encodeTransactionData(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
-            const messageHash = await messageHandler.getMessageHash(messageData);
+            const messageHash = await messageHandler.getMessageHash(ethers.utils.keccak256(messageData));
             const ownerSigs = await buildSignatureBytes([await signHash(user1, messageHash), await signHash(user2, messageHash)]);
             const encodedOwnerSigns = defaultAbiCoder.encode(["bytes"], [ownerSigs]).slice(66);
 

--- a/test/integration/Safe.0xExploit.spec.ts
+++ b/test/integration/Safe.0xExploit.spec.ts
@@ -83,11 +83,11 @@ describe("Safe", async () => {
             contract Test {
                 bool public changeState;
                 uint256 public nonce;
-                function isValidSignature(bytes memory _data, bytes memory _signature) public returns (bytes4) {
+                function isValidSignature(bytes32 _data, bytes memory _signature) public returns (bytes4) {
                     if (changeState) {
                         nonce = nonce + 1;
                     }
-                    return 0x20c13b0b;
+                    return 0x1626ba7e;
                 }
     
                 function shouldChangeState(bool value) public {


### PR DESCRIPTION
**Context:**

Safe contract supports contract signature validation using EIP-1271. The Safe contracts defines [an interface](https://github.com/safe-global/safe-contracts/blob/main/contracts/interfaces/ISignatureValidator.sol) which has a function declaration `isValidSignature(bytes, bytes)` which is used to validating the contract signatures. But, [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) defines `isValidSignature(bytes32,bytes)` for validating contract signatures. This PR addresses this issue by removing the use of legacy implementation of EIP-1271.

Fixes: https://github.com/safe-global/safe-contracts/issues/391
Forum discussion: https://forum.safe.global/t/safe-contract-v1-5-0/3383

**Motivation**

- By complying to updated EIP-1271 standard will allow safe contracts to interact with other contracts and systems that adhere to the latest version of EIP-1271.

**Changes proposed in the PR:**

- [x] Remove use of `isValidSignature(bytes, bytes)` in the interface and replace with `isValidSignature(bytes32,bytes)`
- [x] Deprecate use of `data` parameter with checking signatures. The `checkNSignatures` and `checkSignatures` functions still has the placeholder for this parameter but it is not used anymore.
- [x] Update value of variable `EIP1271_MAGIC_VALUE` to `0x1626ba7e` as per updated EIP-1271 definition.
- [x] Remove variable `UPDATED_MAGIC_VALUE` from `CompatibilityFallbackHandler.sol` as not needed anymore. 
- [x] Fix failing test cases
- [x] Remove test cases for `isValidSignature(bytes, bytes)`
- [x] Remove `isValidSignature(bytes, bytes)` and update `isValidSignature(bytes32, bytes)` in `CompatibilityFallbackHandler.sol`. [link to diff](https://github.com/safe-global/safe-contracts/pull/581/files#diff-8f962f6dc833091675056d29e3ee1ad34c70d259a6c6e9371c732e78a7155359) 
- [x] Remove error code`GS027` (Data Hash and hash of the pre-image data do not match) as not needed anymore.