### PR TITLE
Chore: skip test files in coverage, use SafeL2 contract for coverage calculation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,5 @@ ERC4337_TEST_BUNDLER_URL=
 ERC4337_TEST_NODE_URL=
 ERC4337_TEST_SINGLETON_ADDRESS=
 ERC4337_TEST_SAFE_FACTORY_ADDRESS=
+# (Optional) Tells the test runner which Safe Singleton Contract to use for testing: Safe or SafeL2. Defaults to Safe.
+SAFE_CONTRACT_UNDER_TEST="Safe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 18.17.1
-                  cache: 'npm'
-            - run: npm ci 
+                  cache: "npm"
+            - run: npm ci
             - run: npm run build
-            - run: npm run coverage
+            - run: SAFE_CONTRACT_UNDER_TEST=SafeL2 npm run coverage
             - name: Coveralls
               uses: coverallsapp/github-action@master
               with:
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 18.17.1
-                  cache: 'npm'
+                  cache: "npm"
             - run: npm ci
             - run: npm run lint:sol && npm run lint:ts && npm run lint:sol:prettier
     tests-other:
@@ -40,8 +40,8 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 18.17.1
-                  cache: 'npm'
-            - run: npm ci 
+                  cache: "npm"
+            - run: npm ci
             - run: npm run build
             - run: npm run coverage
             - name: Coveralls
@@ -65,5 +65,5 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 18.17.1
-                  cache: 'npm'
+                  cache: "npm"
             - run: (npm ci && npm run build && npx hardhat codesize --contractname Safe && npm run benchmark) || echo "Benchmark failed"

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,13 @@
 module.exports = {
-    skipFiles: ["test/Token.sol", "test/ERC20Token.sol", "test/TestHandler.sol", "test/ERC1155Token.sol"],
+    skipFiles: [
+        "test/Token.sol",
+        "test/ERC20Token.sol",
+        "test/TestHandler.sol",
+        "test/ERC1155Token.sol",
+        "test/DelegateCaller.sol",
+        "test/Test4337ModuleAndHandler.sol",
+        "test/TestNativeTokenReceiver.sol",
+    ],
     mocha: {
         grep: "@skip-on-coverage", // Find everything with this tag
         invert: true, // Run the grep's inverse set.


### PR DESCRIPTION
This PR:
- Skips test files that were introduced during work on 1.4.1 and 1.5.0 and negatively affected test coverage
- Includes the environment variable used for Safe Contract instance under testing to the sample env file
- Use SafeL2 contract for the coverage test 