### PR TITLE
Feature: Signatures rule fix by restoring the prover options from the original PR

### DIFF
--- a/certora/conf/signatures.conf
+++ b/certora/conf/signatures.conf
@@ -3,13 +3,13 @@
         "certora/harnesses/SafeHarness.sol"
     ],
     "hashing_length_bound": "352",
-    "loop_iter": "3",
+    "loop_iter": "2",
     "msg": "Safe Signatures Rules",
     "optimistic_hashing": true,
     "optimistic_loop": true,
     "process": "emv",
     "prover_args": [
-        " -optimisticFallback true -s z3 -copyLoopUnroll 5 -mediumTimeout 5 -depth 30"
+        "-optimisticFallback true -mediumTimeout 30"
     ],
     "rule_sanity": "basic",
     "solc": "solc7.6",


### PR DESCRIPTION
The checkSignatures verification timed out on the CI on main. I looked into it, and the reason could be the options we pass to the prover. I restored the options from the [original PR](https://github.com/safe-global/safe-contracts/pull/661) from Jochen in an attempt to fix this.

Fixes #681 