### PR TITLE
Prefer `this` over `msg.sender` to refer to the safe

### DIFF
--- a/contracts/test/Test4337ModuleAndHandler.sol
+++ b/contracts/test/Test4337ModuleAndHandler.sol
@@ -50,8 +50,7 @@ contract Test4337ModuleAndHandler {
     }
 
     function execTransaction(address to, uint256 value, bytes calldata data) external payable {
-        address payable safeAddress = payable(msg.sender);
-        ISafe safe = ISafe(safeAddress);
+        ISafe safe = ISafe(address(this));
         require(safe.execTransactionFromModule(to, value, data, 0), "tx failed");
     }
 


### PR DESCRIPTION
`msg.sender` refers to the safe only because of the way safe's module system works via an internal call. (Related to how `_msgSender()` is needed to get the 'real' msg sender.)

To my knowledge, `address(this)` should be equivalent. If so, it should be preferred because it is much more clear.