### PR TITLE
Add pre-commit hook for linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,40 @@
 name: safe-contracts
 on: [push, pull_request]
+env:
+    NODE_VERSION: 18.17.1
 
 jobs:
+    lint-solidity:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "npm"
+            - run: npm ci
+            - run: npm run lint:sol:prettier
+            - run: npm run lint:sol
+
+    lint-typescript:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "npm"
+            - run: npm ci
+            - run: npm run lint:ts:prettier
+            - run: npm run lint:ts
+
     tests:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version: 18.17.1
+                  node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
             - run: npm ci
             - run: npm run build
@@ -17,16 +43,7 @@ jobs:
               uses: coverallsapp/github-action@master
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-    lint:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
-              with:
-                  node-version: 18.17.1
-                  cache: "npm"
-            - run: npm ci
-            - run: npm run lint:sol && npm run lint:ts && npm run lint:sol:prettier
+
     tests-other:
         runs-on: ubuntu-latest
         strategy:
@@ -39,7 +56,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version: 18.17.1
+                  node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
             - run: npm ci
             - run: npm run build
@@ -64,6 +81,6 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version: 18.17.1
+                  node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
             - run: (npm ci && npm run build && npx hardhat codesize --contractname Safe && npm run benchmark) || echo "Benchmark failed"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,21 +1,21 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
-# Redirect output to stderr.
-exec 1>&2
- 
-# prevent it.only or describe.only commited
+npm run lint:sol:prettier
+npm run lint:ts:prettier
+npm run lint:sol
+npm run lint:ts
+
+# Prevent `it.only` or `describe.only` tests commited
 if [ "$allowonlytests" != "true" ] &&
     test $(git diff --cached | grep -E "\b(it|describe).only\("  | wc -l) != 0
 then
     cat <<\EOF
 Error: Attempt to add it.only or describe.only - which may disable all other tests
- 
+
 If you know what you are doing you can disable this check using:
- 
+
     git config hooks.allowonlytests true
 EOF
     exit 1
 fi
- 
-exit 0

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "lint:sol": "solhint 'contracts/**/*.sol'",
         "lint:sol:prettier": "prettier 'contracts/**/*.sol' --list-different",
         "lint:ts": "eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
+        "lint:ts:prettier": "prettier 'src/**/*.ts' 'test/**/*.ts' --list-different",
         "fmt:sol": "prettier 'contracts/**/*.sol' -w",
         "fmt:ts": "prettier 'src/**/*.ts' 'test/**/*.ts' -w",
         "prepack": "npm run build",


### PR DESCRIPTION
- Check linting and formatting of Typescript and Solidity files
- Split linting and formatting checking on Github Actions
- Refactor `NODE_VERSION` on Github Actions into an environment variable
