### PR TITLE
Add ability to implicitly specify "self" in multi-send

### DIFF
--- a/contracts/libraries/MultiSend.sol
+++ b/contracts/libraries/MultiSend.sol
@@ -46,6 +46,8 @@ contract MultiSend {
                 // We offset the load address by 1 byte (operation byte)
                 // We shift it right by 96 bits (256 - 160 [20 address bytes]) to right-align the data and zero out unused data.
                 let to := shr(0x60, mload(add(transactions, add(i, 0x01))))
+                // Defaults `to` to `address(this)` if `address(0)` is provided.
+                to := or(to, mul(iszero(to), address()))
                 // We offset the load address by 21 byte (operation byte + 20 address bytes)
                 let value := mload(add(transactions, add(i, 0x15)))
                 // We offset the load address by 53 byte (operation byte + 20 address bytes + 32 value bytes)

--- a/contracts/libraries/MultiSendCallOnly.sol
+++ b/contracts/libraries/MultiSendCallOnly.sol
@@ -40,6 +40,8 @@ contract MultiSendCallOnly {
                 // We offset the load address by 1 byte (operation byte)
                 // We shift it right by 96 bits (256 - 160 [20 address bytes]) to right-align the data and zero out unused data.
                 let to := shr(0x60, mload(add(transactions, add(i, 0x01))))
+                // Defaults `to` to `address(this)` if `address(0)` is provided.
+                to := or(to, mul(iszero(to), address()))
                 // We offset the load address by 21 byte (operation byte + 20 address bytes)
                 let value := mload(add(transactions, add(i, 0x15)))
                 // We offset the load address by 53 byte (operation byte + 20 address bytes + 32 value bytes)


### PR DESCRIPTION
Safes may want to be able to use multi-send for combining configuring calls such as `enableModule`, `setGuard` with each other or other external calls however specifying the safe's own address is impossible to currently do in initialization calls as the create2 salt for the safe depends on the hash of the `initializer` data which creates an unresolvable circular dependency. Allowing `address(0)` to act as an alias for "self" allows configuring calls to easily be specified at initialization which is useful for people who want to deploy safes that enable certain modules/guards from the start.

**Implementation Explanation**

The expression uses a binary-OR combined with a multiplication to implement a branch-less version of the following statement:

```solidity
to = to == address(0) ? address(this) : to;
```

Here's the reasoning for why `or(to, mul(iszero(to), address())` is equivalent to the above ternary expression:
```javascript
if (to == 0) { or(to, mul(address(), iszero(to))) } else /* to == [1, 2^160-1] */ {  or(to, mul(address(), iszero(to))) }
if (to == 0) { or(0 , mul(address(), 1)         ) } else /* to == [1, 2^160-1] */ {  or(to, mul(address(),     0     )) }
if (to == 0) { or(0 ,     address()             ) } else /* to == [1, 2^160-1] */ {  or(to,                    0      ) }
if (to == 0) {            address()               } else /* to == [1, 2^160-1] */ {     to                              }
```