### PR TITLE
Update certora.yml to pin the cli version

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -29,7 +29,7 @@ jobs:
               with: { java-version: "17", java-package: jre, distribution: semeru }
 
             - name: Install certora cli
-              run: pip install -Iv certora-cli
+              run: pip install -Iv certora-cli==4.13.1
 
             - name: Install solc
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,26 +30,10 @@ jobs:
 
     tests:
         runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
-              with:
-                  node-version: ${{ env.NODE_VERSION }}
-                  cache: "npm"
-            - run: npm ci
-            - run: npm run build
-            - run: SAFE_CONTRACT_UNDER_TEST=SafeL2 npm run coverage
-            - name: Coveralls
-              uses: coverallsapp/github-action@master
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-
-    tests-other:
-        runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                contract-name: ["SafeL2"]
+                contract-name: ["Safe", "SafeL2"]
         env:
             SAFE_CONTRACT_UNDER_TEST: ${{ matrix.contract-name }}
         steps:
@@ -61,10 +45,24 @@ jobs:
             - run: npm ci
             - run: npm run build
             - run: npm run coverage
-            - name: Coveralls
-              uses: coverallsapp/github-action@master
+            - name: Send coverage to Coveralls (parallel)
+              uses: coverallsapp/github-action@v2
               with:
+                  parallel: true
+                  flag-name: run-$
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    finish:
+        runs-on: ubuntu-latest
+        needs: tests
+        if: ${{ always() }}
+        steps:
+            - name: Coveralls Finished
+              uses: coverallsapp/github-action@v2
+              with:
+                  parallel-finished: true
+                  carryforward: "run-Safe,run-SafeL2"
+
     benchmarks:
         runs-on: ubuntu-latest
         strategy:


### PR DESCRIPTION
The certora-cli v5 release on 15th Nov has some breaking changes that can lead to CI runs failing. To avoid these failures, we must change run: `pip install certora-cli` to run: `pip3 install certora-cli==4.13.1` in certora.yml under .github/workflows. This will ensure there are no failures due to the new release.

**EDIT:**
For some reason, the coveralls action started failing with an error.
Example run: https://github.com/safe-global/safe-contracts/actions/runs/6811949628/job/18526604192?pr=696

I updated our coveralls action based on an example for parallel actions at https://github.com/marketplace/actions/coveralls-github-action and https://docs.coveralls.io/parallel-builds (was linked in the failed run)
