### PR TITLE
Pin Certora CLI Version in CI

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -29,7 +29,7 @@ jobs:
               with: { java-version: "17", java-package: jre, distribution: semeru }
 
             - name: Install certora cli
-              run: pip install -Iv certora-cli
+              run: pip install -Iv certora-cli==5.0.5
 
             - name: Install solc
               run: |


### PR DESCRIPTION
This PR pins the Certora CLI version in CI. We started seeing unrelated failures because of, what appears to be, incompatibilities with the new version.